### PR TITLE
Class Match

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A typescript library to manage live football scores
 
 # Notes and assumptions
 
-## Matches
+## **Board**
 
 ### Add Match (start a game)
 
@@ -19,3 +19,40 @@ Even when for this sample it won't make a massive difference, I have taken into 
 ### Update Score
 
 When updating the score of a match I assumpt it will come as one single element with a pair of numbers. Those being structured as first value for the home team, second value for the away team. ie: [0,0]
+
+## **Match**
+
+### Class Match()
+
+Originally I intended to make use of the possibility of setting matches' Map() with their teams array as key (ie: `['Team 1', 'Team 2'] => [0,0]`), but while it does work it also has some caveats.
+
+Maps() would use the reference to the array, not the array's content. Therefore two arrays with same content would fail to be found on the Map(). ie:
+
+```javascript
+const arrayA = ['Team 1', 'Team 2'];
+const arrayB = ['Team 1', 'Team 2'];
+
+const map = new Map();
+
+map.set(arrayA);
+console.log(map.has(arrayA)); // true
+console.log(map.has(arrayB)); // false
+```
+
+#### Solutions considered (chronological ordered):
+
+-   After adding a match (starting a game), return the key used. It would work but it would be an extra element to control and storage by the client, making it less simple to use.
+
+-   Following the last approach: Make the stored match a Class Match() and return the new match. In that way, the client could update the scores without having to pass the teams together with the score (ie: `const matchA = board.addMatch(['Team 1', 'Team 2']); matchA.updateScore([1,0]);`) However this would still have the same problem as above but also increase complexity having to manage somehow the same thing (the match on the board) using two different processes.
+
+-   **(Final decision)** Convert Map() key to a simple string and move teams into the Maps() value together with their score. Better using a Class Match() to follow an OOP approach.
+
+```javascript
+[
+    '["Team 1", "Team 2"]',
+    {
+        score: [0, 0],
+        teams: ['Team 1', 'Team 2'],
+    },
+];
+```

--- a/src/Board/index.test.ts
+++ b/src/Board/index.test.ts
@@ -106,4 +106,25 @@ describe('Board Cases', () => {
         // @ts-ignore
         expect(() => board.finishMatch('Team 01')).toThrowError();
     });
+
+    test("Map() key as array doesn't fit our need", () => {
+        // Map()'s key uses the reference to the array, not its content
+        const map = new Map();
+
+        const arrayA = ['Team A', 'Team B'];
+        const arrayB = ['Team A', 'Team B'];
+
+        map.set(arrayA, [0, 0]);
+        expect(map.delete(arrayB)).toBeFalsy();
+    });
+
+    test('Map() key as stringify array does work better for us', () => {
+        const map = new Map();
+
+        const arrayA = JSON.stringify(['Team A', 'Team B']);
+        const arrayB = JSON.stringify(['Team A', 'Team B']);
+
+        map.set(arrayA, []);
+        expect(map.delete(arrayB)).toBeTruthy();
+    });
 });

--- a/src/Match/index.test.ts
+++ b/src/Match/index.test.ts
@@ -15,6 +15,7 @@ describe('Match Cases', () => {
     });
 
     test('Fail to set new match: Team needs to be string', () => {
-        expect(() => new Match(['Team 01', 'Team 02'])).toThrow(/to be string/);
+        // @ts-ignore
+        expect(() => new Match(['Team 01', [0, 1]])).toThrow(/to be string/);
     });
 });

--- a/src/Match/index.test.ts
+++ b/src/Match/index.test.ts
@@ -8,4 +8,9 @@ describe('Match Cases', () => {
         expect(match.teams.length).toBe(2);
         expect(match.score).toEqual([0, 0]);
     });
+
+    test('Fail to set new match: Missing team', () => {
+        // @ts-ignore
+        expect(() => new Match('Team 01')).toThrow(/needs two teams/);
+    });
 });

--- a/src/Match/index.test.ts
+++ b/src/Match/index.test.ts
@@ -18,4 +18,12 @@ describe('Match Cases', () => {
         // @ts-ignore
         expect(() => new Match(['Team 01', [0, 1]])).toThrow(/to be string/);
     });
+
+    test('Update score', () => {
+        const match = new Match([teams[0], teams[1]]);
+        const score = [3, 4];
+
+        match.updateScore(score);
+        expect(match.score).toEqual(score);
+    });
 });

--- a/src/Match/index.test.ts
+++ b/src/Match/index.test.ts
@@ -1,0 +1,11 @@
+import Match from '.';
+
+describe('Match Cases', () => {
+    const teams = ['Team 01', 'Team 02'];
+
+    test('Set a new match with 0 - 0 default score', () => {
+        const match = new Match([teams[0], teams[1]]);
+        expect(match.teams.length).toBe(2);
+        expect(match.score).toEqual([0, 0]);
+    });
+});

--- a/src/Match/index.test.ts
+++ b/src/Match/index.test.ts
@@ -26,4 +26,11 @@ describe('Match Cases', () => {
         match.updateScore(score);
         expect(match.score).toEqual(score);
     });
+
+    test('Fail to update score: Missing score', () => {
+        const match = new Match([teams[0], teams[1]]);
+
+        expect(() => match.updateScore([3])).toThrow(/not a valid score/);
+        expect(match.score).toEqual([0, 0]);
+    });
 });

--- a/src/Match/index.test.ts
+++ b/src/Match/index.test.ts
@@ -13,4 +13,8 @@ describe('Match Cases', () => {
         // @ts-ignore
         expect(() => new Match('Team 01')).toThrow(/needs two teams/);
     });
+
+    test('Fail to set new match: Team needs to be string', () => {
+        expect(() => new Match(['Team 01', 'Team 02'])).toThrow(/to be string/);
+    });
 });

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -17,6 +17,13 @@ class Match {
         this.teams = teams;
         this.score = [0, 0];
     }
+
+    /**
+     * Update score
+     *
+     * @param {number[]} score
+     */
+    updateScore(score: number[]) {}
 }
 
 export default Match;

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -1,4 +1,4 @@
-import { isValidArray, isString } from '../utils';
+import { isValidArray, isString, isvalidScore } from '../utils';
 
 interface Match {
     teams: string[];
@@ -23,7 +23,12 @@ class Match {
      *
      * @param {number[]} score
      */
-    updateScore(score: number[]) {}
+    updateScore(score: number[]) {
+        if (!isvalidScore(score)) {
+            throw new Error(`That's not a valid score: ${score}`);
+        }
+        this.score = score;
+    }
 }
 
 export default Match;

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -1,5 +1,13 @@
+interface Match {
+    teams: string[];
+    score: number[];
+}
+
 class Match {
-    constructor() {}
+    constructor(teams: string[]) {
+        this.teams = teams;
+        this.score = [0, 0];
+    }
 }
 
 export default Match;

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -1,0 +1,5 @@
+class Match {
+    constructor() {}
+}
+
+export default Match;

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -1,3 +1,5 @@
+import { isValidArray } from '../utils';
+
 interface Match {
     teams: string[];
     score: number[];
@@ -5,6 +7,10 @@ interface Match {
 
 class Match {
     constructor(teams: string[]) {
+        if (!isValidArray(teams)) {
+            throw new Error('A match needs two teams for it to happen');
+        }
+
         this.teams = teams;
         this.score = [0, 0];
     }

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -1,4 +1,4 @@
-import { isValidArray } from '../utils';
+import { isValidArray, isString } from '../utils';
 
 interface Match {
     teams: string[];
@@ -9,6 +9,9 @@ class Match {
     constructor(teams: string[]) {
         if (!isValidArray(teams)) {
             throw new Error('A match needs two teams for it to happen');
+        }
+        if (!isString(teams)) {
+            throw new Error('Teams need to be string');
         }
 
         this.teams = teams;


### PR DESCRIPTION
### What changed:
Replacing how the Board stores every match/game detail. Previously it was on a very simple Map() where the teams array was the key and the score array the value, now its key will be a `stringify` version of the teams array (ie: `"['Team 1', 'Team 2']"`) and as value a Match object containing both teams' name and scores (ie: `{teams: ['Team 1', 'Team 2'], score: [0,0]}`)

### What resolves:
Even when it worked fine using an array as key, Map() uses the reference to the array, not the array's content. Therefore two arrays with the same content would fail to be found on the Map(). ie:

```javascript
const arrayA = ['Team 1', 'Team 2'];
const arrayB = ['Team 1', 'Team 2'];

const map = new Map();

map.set(arrayA);
console.log(map.has(arrayA)); // true
console.log(map.has(arrayB)); // false
```
