### PR TITLE
Refactoring: Board's store solution

### DIFF
--- a/src/Board/index.test.ts
+++ b/src/Board/index.test.ts
@@ -22,7 +22,7 @@ describe('Board Cases', () => {
     });
 
     test.each(matches)('Add $teams match', ({ teams }) => {
-        expectedMatches.set(teams, [0, 0]);
+        expectedMatches.set(JSON.stringify(teams), [0, 0]);
 
         board.addMatch(teams);
         expect(board._matches).toMatchObject(expectedMatches);
@@ -43,7 +43,7 @@ describe('Board Cases', () => {
 
     test.each(matches)('Update $teams score -> $score', ({ teams, score }) => {
         board.updateScore(teams, score);
-        expect(board._matches.get(teams)).toMatchObject(score);
+        expect(board._matches.get(JSON.stringify(teams))).toMatchObject(score);
     });
 
     test("Fail: Can't update. Teams need to be an array", () => {

--- a/src/Board/index.test.ts
+++ b/src/Board/index.test.ts
@@ -22,7 +22,7 @@ describe('Board Cases', () => {
     });
 
     test.each(matches)('Add $teams match', ({ teams }) => {
-        expectedMatches.set(JSON.stringify(teams), [0, 0]);
+        expectedMatches.set(JSON.stringify(teams), { teams: teams, score: [0, 0] });
 
         board.addMatch(teams);
         expect(board._matches).toMatchObject(expectedMatches);
@@ -43,7 +43,10 @@ describe('Board Cases', () => {
 
     test.each(matches)('Update $teams score -> $score', ({ teams, score }) => {
         board.updateScore(teams, score);
-        expect(board._matches.get(JSON.stringify(teams))).toMatchObject(score);
+        expect(board._matches.get(JSON.stringify(teams))).toMatchObject({
+            teams: teams,
+            score: score,
+        });
     });
 
     test("Fail: Can't update. Teams need to be an array", () => {

--- a/src/Board/index.ts
+++ b/src/Board/index.ts
@@ -1,7 +1,8 @@
+import Match from '../Match';
 import { isString, isValidArray, isvalidScore, setKey } from '../utils';
 
 interface Board {
-    _matches: Map<string, number[]>;
+    _matches: Map<string, Match>;
 }
 
 class Board {
@@ -38,7 +39,7 @@ class Board {
                 throw new Error('Teams need to be string');
             }
             this._isTeamPlaying(teams);
-            this._matches.set(setKey(teams), [0, 0]);
+            this._matches.set(setKey(teams), new Match(teams));
         } catch (error) {
             throw new Error(error);
         }
@@ -69,7 +70,8 @@ class Board {
             throw new Error(`There is not ${teams.join(' - ')} match`);
         }
 
-        this._matches.set(mapKey, score);
+        const match = this._matches.get(mapKey);
+        match.updateScore(score);
     }
 
     /**
@@ -95,18 +97,17 @@ class Board {
      * @returns {string[]} Live matches
      */
     getSummary() {
-        return [...this._matches]
+        return [...this._matches.values()]
             .sort((matchA, matchB) => {
-                const totalScoreA = matchA[1][0] + matchA[1][1];
-                const totalScoreB = matchB[1][0] + matchB[1][1];
+                const totalScoreA = matchA.score[0] + matchA.score[1];
+                const totalScoreB = matchB.score[0] + matchB.score[1];
 
                 if (totalScoreA > totalScoreB) return -1;
                 if (totalScoreA < totalScoreB) return 1;
                 return 0;
             })
             .map(match => {
-                const teams = match[0];
-                const score = match[1];
+                const { teams, score } = match;
                 return `${teams[0]} ${score[0]} - ${teams[1]} ${score[1]}`;
             });
     }

--- a/src/Board/index.ts
+++ b/src/Board/index.ts
@@ -1,7 +1,7 @@
-import { isString, isValidArray, isvalidScore } from '../utils';
+import { isString, isValidArray, isvalidScore, setKey } from '../utils';
 
 interface Board {
-    _matches: Map<string[], number[]>;
+    _matches: Map<string, number[]>;
 }
 
 class Board {
@@ -38,7 +38,7 @@ class Board {
                 throw new Error('Teams need to be string');
             }
             this._isTeamPlaying(teams);
-            this._matches.set(teams, [0, 0]);
+            this._matches.set(setKey(teams), [0, 0]);
         } catch (error) {
             throw new Error(error);
         }
@@ -60,14 +60,16 @@ class Board {
         if (!isString(teams)) {
             throw new Error('Teams need to be string');
         }
-        if (!this._matches.has(teams)) {
-            throw new Error(`There is not ${teams.join(' - ')} match`);
-        }
         if (!isvalidScore(score)) {
             throw new Error(`That's not a valid score: ${score}`);
         }
 
-        this._matches.set(teams, score);
+        const mapKey = setKey(teams);
+        if (!this._matches.has(setKey(teams))) {
+            throw new Error(`There is not ${teams.join(' - ')} match`);
+        }
+
+        this._matches.set(mapKey, score);
     }
 
     /**
@@ -79,7 +81,7 @@ class Board {
         if (!isString(teams)) {
             throw new Error('Teams need to be string');
         }
-        if (!this._matches.delete(teams)) {
+        if (!this._matches.delete(setKey(teams))) {
             throw new Error(`${teams.join(' - ')} are not playing at the moment`);
         }
     }

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { isString, isValidArray, isvalidScore } from '.';
+import { isString, isValidArray, isvalidScore, setKey } from '.';
 
 describe('Utils Cases', () => {
     test('Is string', () => {
@@ -49,5 +49,13 @@ describe('Utils Cases', () => {
 
     test('Fail: Score is below zero', () => {
         expect(isvalidScore([-1, 0])).toBeFalsy();
+    });
+
+    test('Set key from any param', () => {
+        expect(setKey(['value a', 'value b'])).toEqual('["value a","value b"]');
+        expect(setKey([0, 1])).toBe('[0,1]');
+        expect(setKey('value a')).toBe('"value a"');
+        expect(setKey(0)).toBe('0');
+        expect(setKey(null)).toBe('null');
     });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,3 +38,11 @@ export const isvalidScore = (score: number[]) => {
 
     return true;
 };
+
+/**
+ * Return a stringify string
+ *
+ * @param {any} value
+ * @returns {string} Stringify string
+ */
+export const setKey = (value: any) => JSON.stringify(value);


### PR DESCRIPTION
### What changed:
Replacing how the Board stores every match/game detail. Previously it was on a very simple Map() where the teams array was the key and the score array the value, now its key will be a `stringify` version of the teams array (ie: `"['Team 1', 'Team 2']"`) and as value a Match object containing both teams' name and scores (ie: `{teams: ['Team 1', 'Team 2'], score: [0,0]}`)

### What resolves:
Even when it worked fine using an array as key, Map() uses the reference to the array, not the array's content. Therefore two arrays with the same content would fail to be found on the Map(). ie:

```javascript
const arrayA = ['Team 1', 'Team 2'];
const arrayB = ['Team 1', 'Team 2'];

const map = new Map();

map.set(arrayA);
console.log(map.has(arrayA)); // true
console.log(map.has(arrayB)); // false
```
