### PR TITLE
Refactor/better privacy fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 A typescript library to manage live football scores
 
-# Notes and assumptions
+---
+
+#  Notes and assumptions
+
+The library has been build following a Class approach because of its more simple and clean syntax (as oposite to prototyping or closure) and also because it will allow multiple instances of the Board.
+
+In a first instance I used the classic ES2015 way of declarating private fields using underscore (`_variable`) because it's widely supported, but with an intention of using the latest options and technology for this test, I have since replaced them with the more up-to-date way of using hash when declaring them (`#variable`).
 
 ## **Board**
 

--- a/src/Board/index.test.ts
+++ b/src/Board/index.test.ts
@@ -25,7 +25,7 @@ describe('Board Cases', () => {
         expectedMatches.set(JSON.stringify(teams), { teams: teams, score: [0, 0] });
 
         board.addMatch(teams);
-        expect(board._matches).toMatchObject(expectedMatches);
+        expect(board.getSummary()).toMatchObject(expectedMatches);
     });
 
     test('Fail: Teams need to be string', () => {
@@ -41,12 +41,9 @@ describe('Board Cases', () => {
         expect(() => board.addMatch(['Team 01', 'Team 10'])).rejects.toThrow(/already playing/);
     });
 
-    test.each(matches)('Update $teams score -> $score', ({ teams, score }) => {
-        board.updateScore(teams, score);
-        expect(board._matches.get(JSON.stringify(teams))).toMatchObject({
-            teams: teams,
-            score: score,
-        });
+    test.each(matches)('Update $teams score -> $score', async ({ teams, score }) => {
+        const response = await board.updateScore(teams, score);
+        expect(response).toBeTruthy();
     });
 
     test("Fail: Can't update. Teams need to be an array", () => {
@@ -71,7 +68,9 @@ describe('Board Cases', () => {
 
     test('Fail: Score needs to be an integer', () => {
         const newValue = [2.1, 5];
-        expect(() => board.updateScore(matches[0].teams, newValue)).rejects.toThrow(/not a valid score/);
+        expect(() => board.updateScore(matches[0].teams, newValue)).rejects.toThrow(
+            /not a valid score/,
+        );
     });
 
     test('Get current matches by total score (summary)', () => {
@@ -91,9 +90,9 @@ describe('Board Cases', () => {
     });
 
     test('Finish match', () => {
-        expect(board._matches.size).toBe(matches.length);
-        board.finishMatch(matches[1].teams)
-        expect(board._matches.size).toBe(matches.length - 1)
+        expect(board.getSummary().length).toBe(matches.length);
+        board.finishMatch(matches[1].teams);
+        expect(board.getSummary().length).toBe(matches.length - 1);
     });
 
     test("Fail: Can't finish a game that isn't happening", () => {

--- a/src/Board/index.ts
+++ b/src/Board/index.ts
@@ -1,13 +1,11 @@
 import Match from '../Match';
 import { isString, isValidArray, isvalidScore, setKey } from '../utils';
 
-interface Board {
-    _matches: Map<string, Match>;
-}
-
 class Board {
+    #matches: Map<string, Match>;
+
     constructor() {
-        this._matches = new Map();
+        this.#matches = new Map();
     }
 
     /**
@@ -15,9 +13,9 @@ class Board {
      *
      * @param {string[]} teams
      */
-    _isTeamPlaying(teams: string[]) {
+    #isTeamPlaying(teams: string[]) {
         teams.forEach(team => {
-            for (let [key, value] of this._matches) {
+            for (let [key, value] of this.#matches) {
                 if (key.includes(team)) {
                     throw new Error(`Team ${team} is already playing`);
                 }
@@ -40,8 +38,8 @@ class Board {
                 if (!isString(teams)) {
                     throw new Error('Teams need to be string');
                 }
-                this._isTeamPlaying(teams);
-                this._matches.set(setKey(teams), new Match(teams));
+                this.#isTeamPlaying(teams);
+                this.#matches.set(setKey(teams), new Match(teams));
                 resolve(true);
             } catch (error) {
                 reject(error);
@@ -58,7 +56,7 @@ class Board {
      */
     updateScore(teams: string[], score: number[]) {
         return new Promise<string | boolean>((resolve, reject) => {
-            try{
+            try {
                 if (!isValidArray(teams)) {
                     throw new Error('`Teams` needs to be passed as an array of 2 elements');
                 }
@@ -73,11 +71,11 @@ class Board {
                 }
 
                 const mapKey = setKey(teams);
-                if (!this._matches.has(setKey(teams))) {
+                if (!this.#matches.has(setKey(teams))) {
                     throw new Error(`There is not ${teams.join(' - ')} match`);
                 }
 
-                const match = this._matches.get(mapKey);
+                const match = this.#matches.get(mapKey);
                 match.updateScore(score);
                 resolve(true);
             } catch (error) {
@@ -98,7 +96,7 @@ class Board {
                 if (!isString(teams)) {
                     throw new Error('Teams need to be string');
                 }
-                if (!this._matches.delete(setKey(teams))) {
+                if (!this.#matches.delete(setKey(teams))) {
                     throw new Error(`${teams.join(' - ')} are not playing at the moment`);
                 }
                 resolve(true);
@@ -117,7 +115,7 @@ class Board {
      * @returns {string[]} Live matches
      */
     getSummary() {
-        return [...this._matches.values()]
+        return [...this.#matches.values()]
             .sort((matchA, matchB) => {
                 const totalScoreA = matchA.score[0] + matchA.score[1];
                 const totalScoreB = matchB.score[0] + matchB.score[1];


### PR DESCRIPTION
### What changes:
Privacy field declarations have been replaced by the more secure and up-to-date hash `#` method.

### What resolves:
While the ES2015 way of using underscore `_` is widely compatible nowadays, to make it more secure and inaccessible it could become a bit more verbose. However, the latest use of `#` has proven to be a better way of declaring them and it has already become compatible with all main browsers.