### PR TITLE
Export Board()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { default as Board } from './Board';


### PR DESCRIPTION
### What changes:
Entry point `src/index.ts` will export Board by default.

### What resolves:
Without exporting it, there won't be a library to use!