### PR TITLE
Package name replaced with 'football-score-board'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "footballscoreboard",
-  "version": "1.0.0",
-  "description": "",
-  "author": "Alberto Cerveto",
-  "license": "ISC",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "/dist"
-  ],
-  "scripts": {
-    "test": "jest"
-  },
-  "dependencies": {
-    "@types/jest": "^29.2.4",
-    "jest": "^29.3.1",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
-  },
-  "devDependencies": {
-    "ts-jest": "^29.0.3"
-  }
+    "name": "football-score-board",
+    "version": "1.0.0",
+    "description": "",
+    "author": "Alberto Cerveto",
+    "license": "ISC",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "files": [
+        "/dist"
+    ],
+    "scripts": {
+        "test": "jest"
+    },
+    "dependencies": {
+        "@types/jest": "^29.2.4",
+        "jest": "^29.3.1",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.4"
+    },
+    "devDependencies": {
+        "ts-jest": "^29.0.3"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,9 +672,9 @@
   integrity sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==
 
 "@types/prettier@^2.1.5":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
-  integrity sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
+  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"


### PR DESCRIPTION
### What changes:
The package name has been replaced by "football-score-board".

What ### resolves
`football-score-board` is more readable