### PR TITLE
Bugfix/not allow same home and away team

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "football-score-board",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "",
     "author": "Alberto Cerveto",
     "license": "ISC",

--- a/src/Board/index.test.ts
+++ b/src/Board/index.test.ts
@@ -41,6 +41,12 @@ describe('Board Cases', () => {
         expect(() => board.addMatch(['Team 01', 'Team 10'])).rejects.toThrow(/already playing/);
     });
 
+    test("Fail: Can't add match. Both teams are the same", () => {
+        expect(() => board.addMatch(['Team 01', 'Team 01'])).rejects.toThrow(
+            /two different strings/,
+        );
+    });
+
     test.each(matches)('Update $teams score -> $score', async ({ teams, score }) => {
         const response = await board.updateScore(teams, score);
         expect(response).toBeTruthy();
@@ -48,12 +54,12 @@ describe('Board Cases', () => {
 
     test("Fail: Can't update. Teams need to be an array", () => {
         // @ts-ignore
-        expect(() => board.updateScore('Team 01', [0, 1])).rejects.toThrow(/as an array/);
+        expect(() => board.updateScore('Team 01', [0, 1])).rejects.toThrow(/two different strings/);
     });
 
     test("Fail: Can't update. Invalid score", () => {
         // @ts-ignore
-        expect(() => board.updateScore(matches[0].teams, 0)).rejects.toThrow(/as an array/);
+        expect(() => board.updateScore(matches[0].teams, 0)).rejects.toThrow(/not a valid score:/);
     });
 
     test("Fail: Can't update. Teams need to be string", () => {

--- a/src/Board/index.ts
+++ b/src/Board/index.ts
@@ -33,7 +33,7 @@ class Board {
         return new Promise<string | boolean>((resolve, reject) => {
             try {
                 if (!isValidArray(teams)) {
-                    throw new Error('`Teams` needs to be passed as an array of 2 elements');
+                    throw new Error('Teams have to be two different strings');
                 }
                 if (!isString(teams)) {
                     throw new Error('Teams need to be string');
@@ -58,10 +58,7 @@ class Board {
         return new Promise<string | boolean>((resolve, reject) => {
             try {
                 if (!isValidArray(teams)) {
-                    throw new Error('`Teams` needs to be passed as an array of 2 elements');
-                }
-                if (!isValidArray(score)) {
-                    throw new Error('`Score` needs to be passed as an array of 2 elements');
+                    throw new Error('Teams have to be two different strings');
                 }
                 if (!isString(teams)) {
                     throw new Error('Teams need to be string');

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -30,6 +30,11 @@ describe('Utils Cases', () => {
         expect(isValidArray('a')).toBeFalsy();
     });
 
+    test('Cannot contain the same values', () => {
+        expect(isValidArray(['a', 'a'])).toBeFalsy();
+        expect(isValidArray(['2', 2])).toBeFalsy();
+    });
+
     test('Score is valid', () => {
         expect(isvalidScore([2, 4])).toBeTruthy();
     });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export const isString = (values: any | any[]) => {
  * @returns {boolean}
  */
 export const isValidArray = (parameter: (string | number)[]) => {
-    return typeof parameter === 'object' && parameter.length === 2;
+    return typeof parameter === 'object' && parameter.length === 2 && parameter[0] != parameter[1];
 };
 
 /**
@@ -31,6 +31,7 @@ export const isValidArray = (parameter: (string | number)[]) => {
  * @returns {boolean}
  */
 export const isvalidScore = (score: number[]) => {
+    if (typeof score !== 'object') return false;
     if (score.length !== 2) return false;
     if (!score.every(value => !isNaN(value))) return false;
     if (!score.every(value => Number.isInteger(value))) return false;


### PR DESCRIPTION
### What changes:
Before adding a new match, there will be a validation to avoid having a match with the same team for both home and away teams.

### What resolves:
If the match happens to include the same team for both parties, it would be accepted. That's basically because it was only checking if the team was already playing.