### PR TITLE
Feature/extra checks for teams array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "football-score-board",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "",
     "author": "Alberto Cerveto",
     "license": "ISC",

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -18,13 +18,14 @@ describe('Utils Cases', () => {
     });
 
     test('Is a valid array', () => {
-        expect(areValidTeams(['a ', '2'])).toBeTruthy();
+        expect(areValidTeams(['a ', 'a2b'])).toBeTruthy();
     });
 
     test('Is not a valid array', () => {
         expect(areValidTeams(['a', 'b', 'c'])).toBeFalsy();
         expect(areValidTeams(['a', 2])).toBeFalsy();
         expect(areValidTeams(['', ' '])).toBeFalsy();
+        expect(areValidTeams(['1', '2'])).toBeFalsy();
     });
 
     test('Is not an array', () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,8 +24,8 @@ export const areValidTeams = (parameter: (string | number)[]) => {
     return (
         typeof parameter === 'object' &&
         parameter.length === 2 &&
-        typeof parameter[0] === 'string' &&
-        typeof parameter[1] === 'string' &&
+        !Number.isInteger(Number.parseInt(parameter[0] as string)) &&
+        !Number.isInteger(Number.parseInt(parameter[1] as string)) &&
         parameter[0] != parameter[1] &&
         (parameter[0] as string).trimEnd().trimStart() != '' &&
         (parameter[1] as string).trimEnd().trimStart() != ''


### PR DESCRIPTION
### What changes:
Before setting as valid a team, it will try to parse its name as int.

### What resolves:
We won't allow teams' name to be just numbers